### PR TITLE
import pandas before kymatio

### DIFF
--- a/src/05_compute-scattering.py
+++ b/src/05_compute-scattering.py
@@ -1,9 +1,10 @@
+import pandas as pd
+
 import datetime
 from kymatio import Scattering1D
 import librosa
 import numpy as np
 import os
-import pandas as pd
 import pickle
 import time
 import torch


### PR DESCRIPTION
fixes a bug in Kymatio

Traceback:

```
>>> import pandas as pd
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/__init__.py", line 54, in <module>
    from pandas.core.api import (
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/core/api.py", line 29, in <module>
    from pandas.core.groupby import Grouper, NamedAgg
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/core/groupby/__init__.py", line 1, in <module>
    from pandas.core.groupby.generic import DataFrameGroupBy, NamedAgg, SeriesGroupBy
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/core/groupby/generic.py", line 60, in <module>
    from pandas.core.frame import DataFrame
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/core/frame.py", line 124, in <module>
    from pandas.core.series import Series
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/core/series.py", line 4572, in <module>
    Series._add_series_or_dataframe_operations()
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/core/generic.py", line 10351, in _add_series_or_dataframe_operations
    from pandas.core.window import EWM, Expanding, Rolling, Window
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/core/window/__init__.py", line 1, in <module>
    from pandas.core.window.ewm import EWM  # noqa:F401
  File "/home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/core/window/ewm.py", line 5, in <module>
    import pandas._libs.window.aggregations as window_aggregations
ImportError: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /home/vl1019/miniconda3/envs/w2s/lib/python3.7/site-packages/pandas/_libs/window/aggregations.cpython-37m-x86_64-linux-gnu.so)
```